### PR TITLE
Chain query endpoint

### DIFF
--- a/src/routers/api.js
+++ b/src/routers/api.js
@@ -304,4 +304,28 @@ router.post(
 	})
 );
 
+router.get(
+	[
+		"/query/:section/:method",
+		"/query/:section/:method/*",
+	],
+	wrap(async (req, res) => {
+		const api = await apiPromise;
+		let args = req.path.split("/").slice(4);
+		let { section, method } = req.params;
+		let query = api.query[section][method];
+		if (typeof query !== "function") {
+			res.status(400).json({ error: `No such query: ${section}.${method}`});
+			return;
+		}
+
+		try {
+			let result = await api.query[req.params.section][req.params.method](...args);
+			res.status(200).json(result.toJSON());
+		} catch(e) {
+			res.status(400).json({ error: e.message })
+		}
+	})
+);
+
 module.exports = router;


### PR DESCRIPTION
It's a bit hairy regarding types:
1. For keys, whatever is passed needs to be able to be interpreted directly from string by polkadot-js/api. Should work fine for integers, accounts and hashes, which should cover 99% cases.
2. For return values, we do a simple `.toJSON()`, which isn't perfectly consistent. For example, small balances will be returned as integers, while big balances will be returned as hex strings. That said, `new BN()` will support parsing whatever is returned.

Examples:

1. Fetching timestamp:
    ```
    > curl localhost:8060/v1/query/timestamp/now
    1720533672000
    ```
4. Fetching liquid LLM balance:
    ```
    > curl localhost:8060/v1/query/assets/account/1/5CkYuVwK6bRjjaqam76VkPG4xXb1TsmbSQzWrMwaFnQ1nu6z
    {"balance":8162067249164,"status":"Liquid","reason":{"sufficient":null},"extra":null}
    ```
5. Politipooled llm: 
    ````
    > curl localhost:8060/v1/query/llm/llmPolitics/5CkYuVwK6bRjjaqam76VkPG4xXb1TsmbSQzWrMwaFnQ1nu6z
    "0x000000000000000001002891a2863000"
6. Non-existent endpoint:
    ```
    > curl localhost:8060/v1/query/timestamp/nowe
    {"error":"No such query: timestamp.nowe"}
    ```
7. Invalid parameters:
    ```
    > curl localhost:8060/v1/query/timestamp/now/1
    {"error":"timestamp.now() does not take any arguments, 1 found"}
    ```