### PR TITLE
Endpoint for LLD total issuance

### DIFF
--- a/src/routers/api.js
+++ b/src/routers/api.js
@@ -364,4 +364,17 @@ router.get(
 	})
 );
 
+router.get(
+	"/total-issuance/lld",
+	wrap(async (req, res) => {
+		try {
+			const api = await apiPromise;
+			let issuance = await api.query.balances.totalIssuance();
+			res.status(200).json(issuance.toString());
+		} catch(e) {
+			res.status(400).json({ error: e.message })
+		}
+	})
+);
+
 module.exports = router;


### PR DESCRIPTION
```
> curl localhost:8060/v1/total_issuance/lld  # the new endpoint
"156391333999075485406"
> curl localhost:8060/v1/query/balances/totalIssuance # the generic version
"0x00000000000000087a5da1ace45d66de"
```

We return a JSON string, as these numbers may get too large to fit in JSON number.